### PR TITLE
Adding the source code of documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Modular codebase for reinforcement learning models training, testing and visuali
 
 Example for recorded envrionment on various RL agents.
 
-| MountainCar-v0 |  Pendulum-v0 | VideoPinball-v0 | Tennis-v0 |
-|---|---|---|---|
-![MountainCar-v0](gif/mountaincar.gif)|![Pendulum-v0](gif/pendulum.gif)|![VideoPinball-v0](gif/pinball.gif)|![Tennis-v0](gif/tennis.gif)
+| MountainCar-v0                         | Pendulum-v0                      | VideoPinball-v0                     | Tennis-v0                    |
+| -------------------------------------- | -------------------------------- | ----------------------------------- | ---------------------------- |
+| ![MountainCar-v0](gif/mountaincar.gif) | ![Pendulum-v0](gif/pendulum.gif) | ![VideoPinball-v0](gif/pinball.gif) | ![Tennis-v0](gif/tennis.gif) |
 
 ### Requirements
 It is recommended to install the codebase in a virtual environment ([virtualenv](https://pypi.org/project/virtualenv/) or [conda](https://conda.io/en/latest/)). 
@@ -68,6 +68,9 @@ Check [init_flags()](https://github.com/for-ai/rl/blob/master/train.py#L17), [de
 - `render`: Render game play.
 - `record_video`: Record game play.
 - `num_workers`, number of workers.
+
+### Documentation
+More detailed documentation can be found [here](https://rl-codebase.readthedocs.io/en/latest/).
 
 ### Contributing
 We'd love to accept your contributions to this project. Please feel free to open an issue, or submit a pull request as necessary. Contact us [team@for.ai](mailto:team@for.ai) for potential collaborations and joining [FOR.ai](https://for.ai).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## [FOR.ai](https://for.ai) Reinforcement Learning Codebase [![Build Status](https://travis-ci.org/for-ai/rl.svg?branch=master)](https://travis-ci.org/for-ai/rl)
+## [FOR.ai](https://for.ai) Reinforcement Learning Codebase [![Build Status](https://travis-ci.org/for-ai/rl.svg?branch=master)](https://travis-ci.org/for-ai/rl)[![](https://img.shields.io/badge/-documentation-blue)](https://rl-codebase.readthedocs.io/en/latest/) 
 Modular codebase for reinforcement learning models training, testing and visualization.
 
 **Contributors**: [Bryan M. Li](https://github.com/bryanlimy), [Alexander Cowen-Rivers](https://github.com/alexanderimanicowenrivers), [Piotr Kozakowski](https://github.com/koz4k), [David Tao](https://github.com/taodav), [Siddhartha Rao Kamalakara](https://github.com/srk97), [Nitarshan Rajkumar](https://github.com/nitarshan), [Hariharan Sezhiyan](https://github.com/hsezhiyan), [Sicong Huang](https://www.cs.toronto.edu/~huang/), [Aidan N. Gomez](https://github.com/aidangomez)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==2.1.2
+sphinx_rtd_theme
+sphinxcontrib-bibtex

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+# -- Project information -----------------------------------------------------
+
+project = 'rl-codebase'
+copyright = '2019, FOR.ai'
+author = 'FOR.ai'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinxcontrib.bibtex']
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+
+# html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+html_theme_options = {
+    'navigation_depth': 4,
+}

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -1,0 +1,110 @@
+Overview
+=========
+
+Abstract
+--------
+
+Vast reinforcement learning (RL) research groups, such as DeepMind and OpenAI, have their internal (private) reinforcement learning codebases, which enable quick prototyping and comparing of ideas to many SOTA methods. We argue the five fundamental properties of a sophisticated research codebase are; modularity, reproducibility, many RL algorithms pre-implemented, speed and ease of running on different hardware/ integration with visualization packages. Currently, there does not exist any RL codebase, to the author's knowledge, which contains all the five properties, particularly with TensorBoard logging and abstracting away cloud hardware such as TPU's from the user. The codebase aims to help distil the best research practices into the community as well as ease the entry access and accelerate the pace of the field.
+
+Related Work
+------------
+
+There are currently various implementations available for reinforcement learning codebase like OpenAI baselines :cite:`dhariwal:2017`, Stable baselines :cite:`hill:2019`, Tensorforce :cite:`schaarschmidt:2017`, Ray rllib :cite:`liang:2017`, Intel Coach :cite:`caspi:2017`, Keras-RL :cite:`kerasrl:2019`, Dopamine baselines :cite:`castro:2018` and TF-Agents :cite:`guadarramatf`. Ray rllib :cite:`liang:2017` is amongst the strongest of existing RL frameworks, supporting; distributed operations, TensorFlow :cite:`abadi:2016`, PyTorch :cite:`paszke:2017` and multi-agent reinforcement learning (MARL). Unlike Ray rllib, we choose to focus on Tensorflow support, allowing us to integrate specific framework visualisation and experiment tracking into our codebase. On top of this, we are developing a Kuberenetes script for MacOS and Linux users to connect to any cloud computing platform, such as Google TPU’s, Amazon AWS etc. Most other frameworks are plagued with problems like usability issues (difficult to get started and increment over), very little modularity in code (no/ little hierarchy and code reuse), no asynchronous training support, weak support for TensorBoard logging and so on. All these problems are solved by our project, which is a generic codebase built for reinforcement learning (RL) research in Tensorflow :cite:`schaarschmidt:2017`, with favoured RL agents pre-implemented as well as integration with OpenAI Gym :cite:`brockman:2016` environment focusing on quick prototyping and visualisation.
+
+Deep Reinforcement Learning Reinforcement learning refers to a paradigm in artificial intelligence where an agent performs a sequence of actions in an environment to maximise rewards :cite:`sutton:1998`. It is in many ways more general and challenging than supervised learning since it requires no labels to train on; instead, the agent interacts continuously with the environment, gathering more and more data and guiding its learning process.
+
+Introduction: for-ai/rl
+-----------------------
+
+Further to the core ideas mentioned in the beginning, a good research codebase should enable good development practices such as continually checkpointing the model's parameters as well as instantly restoring them to the latest checkpoint when available. Moreover, it should be composed of simple, interchangeable building blocks, making it easy to understand and to prototype new research ideas.
+
+We will first introduce the framework for this project, and then we will detail significant components. Lastly, we will discuss how to get started with training an agent under this framework.
+
+This codebase allows training RL agents by a training script as simple as the below for loop. ::
+
+	$ for epoch in range(epochs):
+    	$ state = env.reset()
+		$ for step in range(max_episode_steps):
+        	$ last_state = state
+        	$ action = agent.act(state)
+        	$ state, reward, done = env.step(action)
+        	$ agent.observe(last_state, action, reward, state)
+        	$ agent.update()
+
+To accomplish this, we chose to modularise the codebase in the hierarchy shown below. ::
+
+	$ rl_codebase
+	$ |- train.py
+	$ |---> memory
+	$ |   |- registry.py
+	$ |---> hparams
+	$ |   |- registry.py
+	$ |---> envs
+	$ |   |- registry.py
+	$ |---> models
+	$ |   |- registry.py
+	$ |---> agents
+	$ |   |- registry.py
+	$ |   |---> algos
+	$ |   |   |- registry.py
+	$ |   |   |---> act_select
+	$ |   |   |   |- registry.py
+	$ |   |   |---> grad_comp
+	$ |   |   |   |- registry.py
+
+
+Our modularisation enables simple and easy-to-read implementation of each component, such as the Agent, Algo and Environment class, as shown below. ::
+
+
+	$ class Agent:
+		$ self.model: Model
+		$ self.algo: Algo
+
+		$ def observe(last_state, action, reward, new_state)
+		$ def act(state) -> action
+		$ def update()
+
+	$ class Algo(Agent):
+		$ def select_action(distribution) -> action
+		$ def compute_gradients(trajectory, parameters) -> gradients
+
+	$ class Environment:
+		$ def reset() -> state
+		$ def step(action) -> state, reward, done
+
+
+The codebase includes agents like Deep Q Network :cite:`mnih:2013`, Noisy DQN :cite:`plappert:2017`, Vanilla Policy Gradient :cite:`sutton:2000`, Deep Deterministic Policy Gradient :cite:`silver2014deterministic` and Proximal Policy Optimization :cite:`schulman2017proximal`. The project also includes simple random sampling and proportional prioritized experience replay approaches, support for Discrete and Box environments, option to render environment replay and record the replay in a video. The project also gives the possibility to conduct model-free asynchronous training, setting hyperparameters for your algorithm of choice, modularized action and gradient update functions and option to show your training logs in a TensorBoard summary.
+
+In order to run an experiment, run:
+
+``python train.py --sys ... --hparams ... --output_dir ....``
+
+Ideally, “train.py” should never need to be modified for any of the typical single agent environments. It covers the logging of reward, checkpointing, loading, rendering environment/ dealing with crashes and saving the experiments hyperparameters, which takes a significant workload off the average reinforcement learning researcher. 
+
+Below we summerize the key arguments ::
+
+	“--sys”(str) defines the system chosen to run experiment with;  e.g. “local” for running on the local machine. 
+	“--env”(str) specifies the environment. 
+	“--hparam_override”(str) overrides hyperparameters. 
+	“--train_steps”(int) sets training length. 
+	“--test_episodes”(int) tests episodes.
+	“--eval_episodes”(int) sets Validation episodes.
+	“--training"(bool) freeze model weights is set to False. 
+	“--copies”(int) set the number of times to perform multiple versions of training/ testing.
+	“--render”(bool) turns rendering on/ off. 
+	“--record_video”(bool) records the video with, which outputs a .mp4 of each recorded episode.
+	“--num_workers"(int) seamlessly brings our synchronous agent into an asynchronous agent.
+
+Conclusion
+----------
+
+We have outlined the benefits of using a highly modularised reinforcement learning codebase. The next stages of development for the RL codebase are implementing more SOTA model-free RL techniques (GAE, Rainbow, SAC, IMPALA), introducing model-based approaches, such as World Models :cite:`ha:2018`, integrating into an open-sourced experiment managing tool and expanding the codebases compatibility with a broader range of environments, such as Habitat :cite:`savva:2019`. We would also like to see automatic hyperparameter optimization techniques to be integrated, such as Bayesian Optimization method which was crucial to the success of some of DeepMinds most considerable reinforcement learning feats :cite:`chen:2018`.
+
+Acknowledgements
+----------------
+
+We would like to thank all other members of For.ai, for useful discussions and feedback.
+
+References
+----------------
+.. bibliography:: references.bib

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,13 @@
+
+Generic Reinforcment Learning Codebase
+=======================================
+
+
+Contents:
+
+.. toctree::
+   :maxdepth: 4
+   :glob:
+
+   *
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,9 @@
+============
+Installation
+============
+
+Install all dependencies by running::
+
+    $ ./setup.sh
+
+This installation script currently supports Linux and macOS. For macOS users, this installation script supports both Homebrew and Macports. In the event the script fails, we recommend installing all dependencies within a Conda environment.

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,56 @@
+Modules
+========
+
+This section covers the main components of the RL codebase.
+
+Agents
+------
+
+All agents are encapsulated into a single class, ``Agent()``. An agent object is instantiated with the following member variables:
+
+- TensorFlow session
+- Hyperparameters
+- Memory
+- Action function
+- Gradient function
+
+
+Algos
+------
+
+This codebase currently supports the following RL algorithms: ``DDPG``, ``DQN``, ``PPO``, and ``Vanilla Policy Gradient``.
+
+Environments
+--------
+
+The codebase has a single environment class, and two environment subclasses:
+
+- ``class Environment``
+	- ``class CoinRun(Environment)`` as described `here <https://github.com/openai/coinrun/>`_
+	- ``class GymEnv(Environment)`` as descibed `here <https://jair.org/index.php/jair/article/view/10819/25823/>`_ 
+
+The ``Environment`` class, located at ``rl/rl/envs/env.py``, acts as a template contains all the member variables and functions of a standard RL environment. The specific member variables and functions are implemented within the two subclasses.
+
+
+Hyperparameters
+------------
+
+The class to represent hyperparameters, ``HParams``, is located at ``rl/rl/hparams/utils.py``. The default set of hyperparameters located at ``rl/rl/hparams/default.py``.
+
+The list of hyperparameters is located at ``rl/rl/hparams``, segmented into the different RL algorithms each set of hyperparameters belongs to. Each RL algorithms calls the default set of hyperparameters, and depending on different environments, modifies the default set.
+
+For example, the function ``ddpg()`` returns a default set of ``HParams`` and adds a number of fields, while the 
+function ``ddpg_cartpole()`` further modifies some of the hyperparameter fields to fit with the ``Cartpole-v1`` Gym environment
+
+
+Memory
+-------
+
+The base class for memory is located at ``rl/rl/memory/memory.py``. This codebase currently supports three memory types: simple experience reply, sum tree, and prioritized experience replay.
+
+
+Models
+-------
+
+The list of models can be found at ``rl/rl/models/models``. All models are subclassed from Keras models. Each model is instantiated with a network structure and a ``call()`` function to call the forward pass of the network. All layers are taken from the TensorFlow Layers class. 
+

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,0 +1,139 @@
+@article{schulman2017proximal,
+  title={Proximal policy optimization algorithms},
+  author={Schulman, John and Wolski, Filip and Dhariwal, Prafulla and Radford, Alec and Klimov, Oleg},
+  journal={arXiv preprint arXiv:1707.06347},
+  year={2017}
+}
+
+@misc{sutton:1998,
+  title={Introduction to reinforcement learning. Vol. 135},
+  author={Sutton, Richard S and Barto, Andrew G},
+  year={1998},
+  publisher={Cambridge: MIT press}
+}
+
+@article{dhariwal:2017,
+  title={Openai baselines},
+  author={Dhariwal, Prafulla and Hesse, Christopher and Klimov, Oleg and Nichol, Alex and Plappert, Matthias and Radford, Alec and Schulman, John and Sidor, Szymon and Wu, Yuhuai and Zhokhov, Peter},
+  journal={GitHub, GitHub repository},
+  year={2017}
+}
+
+@article{schaarschmidt:2017,
+  title={Tensorforce: A tensorflow library for applied reinforcement learning},
+  author={Schaarschmidt, Michael and Kuhnle, Alexander and Fricke, Kai},
+  journal={Web page},
+  year={2017}
+}
+
+@article{liang:2017,
+  title={Ray rllib: A composable and scalable reinforcement learning library},
+  author={Liang, Eric and Liaw, Richard and Nishihara, Robert and Moritz, Philipp and Fox, Roy and Gonzalez, Joseph and Goldberg, Ken and Stoica, Ion},
+  journal={arXiv preprint arXiv:1712.09381},
+  year={2017}
+}
+
+@article{caspi:2017,
+  title={Reinforcement Learning Coach.(Dec. 2017)},
+  author={Caspi, Itai and Leibovich, Gal and Novik, Gal},
+  journal={URL https://doi. org/10.5281/zenodo},
+  volume={1134899},
+  year={2017}
+}
+
+@inproceedings{abadi:2016,
+  title={Tensorflow: A system for large-scale machine learning},
+  author={Abadi, Mart{\'\i}n and Barham, Paul and Chen, Jianmin and Chen, Zhifeng and Davis, Andy and Dean, Jeffrey and Devin, Matthieu and Ghemawat, Sanjay and Irving, Geoffrey and Isard, Michael and others},
+  booktitle={12th $\{$USENIX$\}$ Symposium on Operating Systems Design and Implementation ($\{$OSDI$\}$ 16)},
+  pages={265--283},
+  year={2016}
+}
+
+@article{brockman:2016,
+  title={Openai gym},
+  author={Brockman, Greg and Cheung, Vicki and Pettersson, Ludwig and Schneider, Jonas and Schulman, John and Tang, Jie and Zaremba, Wojciech},
+  journal={arXiv preprint arXiv:1606.01540},
+  year={2016}
+}
+
+@misc{kerasrl:2019, title={keras-rl/keras-rl}, url={https://github.com/keras-rl/keras-rl}, journal={GitHub}, author={Keras-Rl, Matthias Plappert}, year={2019}, month={Mar}}
+
+@article{castro:2018,
+  title={Dopamine: A research framework for deep reinforcement learning},
+  author={Castro, Pablo Samuel and Moitra, Subhodeep and Gelada, Carles and Kumar, Saurabh and Bellemare, Marc G},
+  journal={arXiv preprint arXiv:1812.06110},
+  year={2018}
+}
+
+@article{mnih:2013,
+  title={Playing atari with deep reinforcement learning},
+  author={Mnih, Volodymyr and Kavukcuoglu, Koray and Silver, David and Graves, Alex and Antonoglou, Ioannis and Wierstra, Daan and Riedmiller, Martin},
+  journal={arXiv preprint arXiv:1312.5602},
+  year={2013}
+}
+
+@article{plappert:2017,
+  title={Parameter space noise for exploration},
+  author={Plappert, Matthias and Houthooft, Rein and Dhariwal, Prafulla and Sidor, Szymon and Chen, Richard Y and Chen, Xi and Asfour, Tamim and Abbeel, Pieter and Andrychowicz, Marcin},
+  journal={arXiv preprint arXiv:1706.01905},
+  year={2017}
+}
+
+@inproceedings{sutton:2000,
+  title={Policy gradient methods for reinforcement learning with function approximation},
+  author={Sutton, Richard S and McAllester, David A and Singh, Satinder P and Mansour, Yishay},
+  booktitle={Advances in neural information processing systems},
+  pages={1057--1063},
+  year={2000}
+}
+
+@inproceedings{silver2014deterministic,
+  title={Deterministic policy gradient algorithms},
+  author={Silver, David and Lever, Guy and Heess, Nicolas and Degris, Thomas and Wierstra, Daan and Riedmiller, Martin},
+  booktitle={ICML},
+  year={2014}
+}
+
+@article{schulman:2017,
+  title={Proximal policy optimization algorithms},
+  author={Schulman, John and Wolski, Filip and Dhariwal, Prafulla and Radford, Alec and Klimov, Oleg},
+  journal={arXiv preprint arXiv:1707.06347},
+  year={2017}
+}
+
+@article{savva:2019,
+  title={Habitat: A platform for embodied ai research},
+  author={Savva, Manolis and Kadian, Abhishek and Maksymets, Oleksandr and Zhao, Yili and Wijmans, Erik and Jain, Bhavana and Straub, Julian and Liu, Jia and Koltun, Vladlen and Malik, Jitendra and others},
+  journal={arXiv preprint arXiv:1904.01201},
+  year={2019}
+}
+
+@article{chen:2018,
+  title={Bayesian optimization in alphago},
+  author={Chen, Yutian and Huang, Aja and Wang, Ziyu and Antonoglou, Ioannis and Schrittwieser, Julian and Silver, David and de Freitas, Nando},
+  journal={arXiv preprint arXiv:1812.06855},
+  year={2018}
+}
+
+@inproceedings{ha:2018,
+  title={Recurrent world models facilitate policy evolution},
+  author={Ha, David and Schmidhuber, J{\"u}rgen},
+  booktitle={Advances in Neural Information Processing Systems},
+  pages={2450--2462},
+  year={2018}
+}
+
+@misc{guadarramatf,
+  title={TF-Agents: A library for reinforcement learning in tensorflow},
+  author={Guadarrama, Sergio and Korattikara, Anoop and Ramirez, Oscar and Castro, Pablo and Holly, Ethan and Fishman, Sam and Wang, Ke and Gonina, Ekaterina and Harris, Chris and Vanhoucke, Vincent and others}
+}
+
+@misc{hill:2019, title={hill-a/stable-baselines}, url={https://github.com/hill-a/stable-baselines}, journal={GitHub}, author={Hill}, year={2019}, month={Jun}}
+
+@article{paszke:2017,
+  title={Pytorch},
+  author={Paszke, Adam and Gross, Sam and Chintala, Soumith and Chanan, Gregory},
+  journal={Computer software. Vers. 0.3},
+  volume={1},
+  year={2017}
+}

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,0 +1,24 @@
+========
+Tutorial
+========
+
+Before you run a full example, it would be to your benefit to install the following:
+
+- Nvidia CUDA on machines with GPUs to enable faster training. Installation instructions `here <https://developer.nvidia.com/cuda-downloads>`_
+- Tensorboard for training visualization. Install by running `pip install tensorboard`
+This tuturial will make use of a Conda environment as the preferred package manager. Installation instructions can be found `here <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_
+
+After installing Conda, create and activate an environment, and install all dependencies within that environment::
+
+	$ conda create -n rl-codebase python=3.6
+	$ conda activate rl-codebase
+	$ pip install -r requirements.txt
+
+To run locally, we will train DQN on the `Carpole-v1` Gym environment::
+
+	$ # start training
+	$ python train.py --sys local --hparams dqn_cartpole --output_dir /tmp/rl-testing
+	$ # run tensorboard
+	$ tensorboard --logdir /tmp/rl-testing
+	$ # test agent
+	$ python train.py --sys local --hparams dqn_cartpole --output_dir /tmp/rl-testing --training False --render True

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,31 @@
+========
+Usage
+========
+
+To start training::
+
+	$ python train.py --sys ... --hparams ... --output_dir ...
+
+Run tensorboard to visualize training::
+
+	$ tensorboard --logdir ...
+
+Test agent::
+
+	$ python train.py --sys ... --hparams ... --output_dir ... --training False --render True
+
+The sys command can be one of two options: ``local`` or ``tpu`` for GCP enabled tpu training. A list of environments and hyperparameters can be found under ``rl/rl/hparams``. A full training and evaluation example can be found in the tutorial section.
+
+Below we summerize the key arguments ::
+
+	“--sys”(str) defines the system chosen to run experiment with;  e.g. “local” for running on the local machine. 
+	“--env”(str) specifies the environment. 
+	“--hparam_override”(str) overrides hyperparameters. 
+	“--train_steps”(int) sets training length. 
+	“--test_episodes”(int) tests episodes.
+	“--eval_episodes”(int) sets Validation episodes.
+	“--training"(bool) freeze model weights is set to False. 
+	“--copies”(int) set the number of times to perform multiple versions of training/ testing.
+	“--render”(bool) turns rendering on/ off. 
+	“--record_video”(bool) records the video with, which outputs a .mp4 of each recorded episode.
+	“--num_workers"(int) seamlessly brings our synchronous agent into an asynchronous agent.

--- a/paper.md
+++ b/paper.md
@@ -36,7 +36,8 @@ output:
 # Abstract 
 
 Vast reinforcement learning (RL) research groups, such as DeepMind and OpenAI, have their internal (private) reinforcement learning codebases, which enable quick prototyping and comparing of ideas to many SOTA methods. We argue the five fundamental properties of a sophisticated research codebase are; modularity, reproducibility, many RL algorithms pre-implemented, speed and ease of running on different hardware/ integration with visualization packages. 
-Currently, there does not exist any RL codebase, to the author's knowledge, which contains all the five properties, particularly with TensorBoard logging and abstracting away cloud hardware such as TPU's from the user. The codebase aims to help distil the best research practices into the community as well as ease the entry access and accelerate the pace of the field. 
+Currently, there does not exist any RL codebase, to the author's knowledge, which contains all the five properties, particularly with TensorBoard logging and abstracting away cloud hardware such as TPU's from the user. The codebase aims to help distil the best research practices into the community as well as ease the entry access and accelerate the pace of the field. More detailed documentation can be found [here](https://rl-codebase.readthedocs.io/en/latest/).
+
 
 # Related Work
 
@@ -108,7 +109,7 @@ class Environment:
 
 The codebase includes agents like Deep Q Network`@mnih:2013`, Noisy DQN`@plappert:2017`, Vanilla Policy Gradient`@sutton:2000`, Deep Deterministic Policy Gradient`@silver2014deterministic` and Proximal Policy Optimization`@schulman2017proximal`. The project also includes simple random sampling and proportional prioritized experience replay approaches, support for Discrete and Box environments, option to render environment replay and record the replay in a video. The project also gives the possibility to conduct model-free asynchronous training, setting hyperparameters for your algorithm of choice, modularized action and gradient update functions and option to show your training logs in a TensorBoard summary.
 
-In order to run an experiment, run. 
+In order to run an experiment, run: 
 
 `python train.py --sys ... --hparams ... --output_dir .... `
 


### PR DESCRIPTION
Transferring the source code of documentation from https://github.com/hsezhiyan/forai-rl-docs to here. The online documentation can be found here: https://rl-codebase.readthedocs.io/en/latest/